### PR TITLE
Feature/support python3.6

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ verify_ssl = true
 [packages]
 esptool = "*"
 requests = "*"
+pyserial = "*"
 
 [requires]
 python_version = "3.5"

--- a/commands/eraseos.py
+++ b/commands/eraseos.py
@@ -21,6 +21,6 @@ def command(args):
 
     print()
     proc = subprocess.run(
-        "esptool.py --port {} erase_flash".format(selected_port),
+        "python -m esptool --port {} erase_flash".format(selected_port),
         shell=True
     )

--- a/commands/flashos.py
+++ b/commands/flashos.py
@@ -13,9 +13,7 @@ def get_latest_release():
     headers = {'Content-Type': 'application/json'}
     resp = requests.get('https://api.github.com/repos/obniz/obnizos-esp32w/releases', headers=headers)
     json_data = resp.json()
-    json_data.sort(
-        key=lambda x: datetime.datetime.fromisoformat(x['published_at'].replace('Z', '+00:00')),
-        reverse=True)
+    json_data.sort(key=lambda x: x['published_at'], reverse=True)
     tag_name = json_data[0]['tag_name']
     return tag_name
 

--- a/commands/flashos.py
+++ b/commands/flashos.py
@@ -43,7 +43,7 @@ def command(args):
         # obnizOSの書き込み
         print()
         proc = subprocess.run(
-            "esptool.py --port {} -b {} --after hard_reset write_flash 0x1000 bootloader.bin 0x10000 obniz.bin 0x8000 partitions.bin".format(selected_port, args.bps),
+            "python -m esptool --port {} -b {} --after hard_reset write_flash 0x1000 bootloader.bin 0x10000 obniz.bin 0x8000 partitions.bin".format(selected_port, args.bps),
             shell=True,
             cwd=dirname
         )


### PR DESCRIPTION
- datetimeのfromisoformatがPython3.7必須だったので、3.6で動作するよう変更
- Windowsでも動作するよう、esptoolの呼び出し方を変更
- Pipfileに`pyserial = "*"`を追加